### PR TITLE
Fix the incorrect fetch partial parsing

### DIFF
--- a/pymap/admin/__init__.py
+++ b/pymap/admin/__init__.py
@@ -13,7 +13,6 @@ from ssl import SSLContext
 from grpclib.events import listen, RecvRequest
 from grpclib.health.check import ServiceStatus
 from grpclib.health.service import Health, OVERALL
-from grpclib.server import Server
 from pymap.context import cluster_metadata
 from pymap.interfaces.backend import ServiceInterface
 from pymapadmin import is_compatible, __version__ as server_version
@@ -21,6 +20,7 @@ from pymapadmin.local import socket_file, token_file
 
 from .errors import get_incompatible_version_error
 from .handlers import handlers
+from .server import Server
 from .typing import Handler
 
 __all__ = ['AdminService']

--- a/pymap/admin/server.py
+++ b/pymap/admin/server.py
@@ -1,0 +1,32 @@
+
+from __future__ import annotations
+
+from asyncio import AbstractEventLoop
+
+from grpclib.server import Server as _Server
+
+__all__ = ['Server']
+
+
+class Server(_Server):
+    """The :class:`~grpclib.server.Server` class included with :mod:`grpclib`
+    has typing issues due to some missing methods. These methods do not seem to
+    be part of its public API, so they should be implemented to simply raise
+    exceptions.
+
+    Note:
+        If this is fixed upstream, this class should be removed.
+
+    """
+
+    def get_loop(self) -> AbstractEventLoop:
+        raise NotImplementedError()
+
+    def is_serving(self) -> bool:
+        raise NotImplementedError()
+
+    async def serve_forever(self) -> None:
+        raise NotImplementedError()
+
+    async def start_serving(self) -> None:
+        raise NotImplementedError()

--- a/pymap/concurrent.py
+++ b/pymap/concurrent.py
@@ -16,8 +16,9 @@ from collections.abc import Awaitable, MutableSet, Sequence, AsyncIterator
 from concurrent.futures import Executor, ThreadPoolExecutor
 from contextlib import asynccontextmanager, AbstractAsyncContextManager
 from contextvars import copy_context, Context
+from functools import partial
 from threading import local, Event as _threading_Event, Lock as _threading_Lock
-from typing import cast, TypeVar, TypeAlias
+from typing import TypeVar, TypeAlias
 from weakref import WeakSet
 
 __all__ = ['Subsystem', 'Event', 'ReadWriteLock', 'FileLock', 'EventT', 'RetT']
@@ -135,8 +136,8 @@ class _ThreadingSubsystem(Subsystem):  # pragma: no cover
 
     def _run_in_thread(self, future: Awaitable[RetT], ctx: Context) -> RetT:
         loop = self._local.event_loop
-        ret = ctx.run(loop.run_until_complete, future)
-        return cast(RetT, ret)
+        foo: partial[RetT] = partial(loop.run_until_complete, future)
+        return ctx.run(foo)
 
     def new_rwlock(self) -> _ThreadingReadWriteLock:
         return _ThreadingReadWriteLock()

--- a/pymap/imap/__init__.py
+++ b/pymap/imap/__init__.py
@@ -7,8 +7,8 @@ import logging
 import re
 import sys
 from argparse import ArgumentParser
-from asyncio import shield, StreamReader, StreamWriter, AbstractServer, \
-    CancelledError, TimeoutError
+from asyncio import shield, StreamReader, StreamWriter, WriteTransport, \
+    AbstractServer, CancelledError, TimeoutError
 from base64 import b64encode, b64decode
 from collections.abc import Awaitable, Iterable
 from contextlib import closing, AsyncExitStack
@@ -279,6 +279,7 @@ class IMAPConnection:
         ssl_context = self.config.ssl_context
         new_transport = await loop.start_tls(
             transport, protocol, ssl_context, server_side=True)
+        assert isinstance(new_transport, WriteTransport)
         new_protocol = new_transport.get_protocol()
         new_writer = StreamWriter(new_transport, new_protocol,
                                   self.reader, loop)

--- a/pymap/sieve/manage/__init__.py
+++ b/pymap/sieve/manage/__init__.py
@@ -6,7 +6,7 @@ import binascii
 import logging
 import re
 from argparse import ArgumentParser
-from asyncio import StreamReader, StreamWriter
+from asyncio import StreamReader, StreamWriter, WriteTransport
 from base64 import b64encode, b64decode
 from collections.abc import Mapping
 from contextlib import closing, AsyncExitStack
@@ -283,6 +283,7 @@ class ManageSieveConnection:
         protocol = transport.get_protocol()
         new_transport = await loop.start_tls(
             transport, protocol, ssl_context, server_side=True)
+        assert isinstance(new_transport, WriteTransport)
         new_protocol = new_transport.get_protocol()
         new_writer = StreamWriter(new_transport, new_protocol,
                                   self.reader, loop)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open('LICENSE.md') as f:
     license = f.read()
 
 setup(name='pymap',
-      version='0.27.0',
+      version='0.27.1',
       author='Ian Good',
       author_email='ian@icgood.net',
       description='Lightweight, asynchronous IMAP serving in Python.',

--- a/test/server/test_fetch.py
+++ b/test/server/test_fetch.py
@@ -231,7 +231,7 @@ class TestFetch(TestBase):
         transport.push_login()
         transport.push_select(b'Sent')
         transport.push_readline(
-            b'fetch1 FETCH 2 (BINARY[1]<5.22>)\r\n')
+            b'fetch1 FETCH 2 (BINARY[1]<5.17>)\r\n')
         transport.push_write(
             b'* 2 FETCH (BINARY[1]<5> ~{17}\r\n'
             + 'ⅬⅬՕ ᎳоᏒ'.encode('utf-8') +

--- a/test/test_parsing_command_select.py
+++ b/test/test_parsing_command_select.py
@@ -81,6 +81,12 @@ class TestFetchCommand(unittest.TestCase):
                               FetchAttribute(b'ENVELOPE')], ret.attributes)
         self.assertEqual(b'  ', buf)
 
+    def test_parse_uid_list(self):
+        ret, buf = UidFetchCommand.parse(b' 265 (BODY.PEEK[1]<208.78> '
+                                         b'BODY.PEEK[2]<2027.77>)\n  ',
+                                         Params())
+        self.assertEqual(b'  ', buf)
+
     def test_parse_macro_all(self):
         ret, buf = FetchCommand.parse(b' 1,2,3 ALL\n  ', Params())
         self.assertEqual([1, 2, 3], ret.sequence_set.value)

--- a/test/test_parsing_specials.py
+++ b/test/test_parsing_specials.py
@@ -6,9 +6,9 @@ from pymap.parsing import Params
 from pymap.parsing.exceptions import NotParseable, UnexpectedType, \
     InvalidContent
 from pymap.parsing.specials import AString, Tag, Mailbox, DateTime, Flag, \
-    StatusAttribute, SequenceSet, FetchAttribute, SearchKey, ObjectId, \
-    ExtensionOptions
+    StatusAttribute, SequenceSet, SearchKey, ObjectId, ExtensionOptions
 from pymap.parsing.state import ParsingState
+from pymap.parsing.specials.fetchattr import FetchPartial, FetchAttribute
 from pymap.parsing.specials.sequenceset import MaxValue
 
 
@@ -223,12 +223,12 @@ class TestFetchAttribute(unittest.TestCase):
 
     def test_parse(self):
         ret, buf = FetchAttribute.parse(
-            b'body.peek[1.2.HEADER.FIELDS (A B)]<4.5>  ', Params())
+            b'body.peek[1.2.HEADER.FIELDS (A B)]<4.2>  ', Params())
         self.assertEqual(b'BODY.PEEK', ret.value)
         self.assertEqual([1, 2], ret.section.parts)
         self.assertEqual(b'HEADER.FIELDS', ret.section.specifier)
         self.assertEqual({b'A', b'B'}, ret.section.headers)
-        self.assertEqual((4, 5), ret.partial)
+        self.assertEqual(FetchPartial(4, 2), ret.partial)
         self.assertEqual(b'  ', buf)
 
     def test_parse_simple(self):
@@ -283,8 +283,8 @@ class TestFetchAttribute(unittest.TestCase):
         self.assertEqual(b'ENVELOPE', bytes(attr1))
         section = FetchAttribute.Section((1, 2), b'STUFF',
                                          frozenset({b'A', b'B'}))
-        attr2 = FetchAttribute(b'BODY', section, (4, 5))
-        self.assertEqual(b'BODY[1.2.STUFF (A B)]<4.5>', bytes(attr2))
+        attr2 = FetchAttribute(b'BODY', section, FetchPartial(4, 2))
+        self.assertEqual(b'BODY[1.2.STUFF (A B)]<4.2>', bytes(attr2))
         self.assertEqual(b'BODY[1.2.STUFF (A B)]<4>',
                          bytes(attr2.for_response))
 


### PR DESCRIPTION
Fix #131

The original implementation interpreted the partial fetch arguments as a start and end octet, but the RFC states they are a start octet and a length. This also causes incorrect parsing failures because there was a check that the first number was less than the second number, which does not make sense with corrected assumptions.