### PR TITLE
Make password hashing more robust

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
-extend-ignore = B024
 extend-select = B901, B902, B903, B904

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## The MIT License (MIT)
 
-Copyright (c) 2021 Ian Good
+Copyright (c) 2022 Ian Good
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ import cloud_sptheme as csp  # type: ignore
 # -- Project information -----------------------------------------------------
 
 project = 'pymap'
-copyright = '2021, Ian Good'
+copyright = '2022, Ian Good'
 author = 'Ian Good'
 
 # The short X.Y version

--- a/pymap/admin/handlers/__init__.py
+++ b/pymap/admin/handlers/__init__.py
@@ -1,7 +1,6 @@
 
 from __future__ import annotations
 
-from abc import ABCMeta
 from collections.abc import Mapping, Set, AsyncGenerator
 from contextlib import closing, asynccontextmanager, AsyncExitStack
 from typing import TypeAlias, Final
@@ -22,10 +21,10 @@ __all__ = ['handlers', 'BaseHandler', 'LoginHandler']
 _Metadata: TypeAlias = Mapping[str, str | bytes] | None
 
 #: Registers new admin handler plugins.
-handlers: Plugin[type[BaseHandler]] = Plugin('pymap.admin.handlers')
+handlers: Plugin[BaseHandler] = Plugin('pymap.admin.handlers')
 
 
-class BaseHandler(Handler, metaclass=ABCMeta):
+class BaseHandler(Handler):
     """Base class for implementing admin request handlers.
 
     Args:

--- a/pymap/admin/handlers/user.py
+++ b/pymap/admin/handlers/user.py
@@ -68,11 +68,11 @@ class UserHandlers(UserBase, BaseHandler):
         async with (self.catch_errors('SetUser') as result,
                     self.login_as(stream.metadata, request.user) as identity):
             user_data = request.data
-            password = self.config.hash_context.hash(user_data.password) \
+            password = user_data.password \
                 if user_data.HasField('password') else None
             params: Mapping[str, str] = user_data.params
-            metadata = UserMetadata(self.config, request.user,
-                                    password=password, **params)
+            metadata = await UserMetadata.create(
+                self.config, request.user, password=password, params=params)
             await identity.set(metadata)
         resp = UserResponse(result=result, username=request.user)
         await stream.send_message(resp)

--- a/pymap/backend/__init__.py
+++ b/pymap/backend/__init__.py
@@ -7,4 +7,4 @@ from ..plugin import Plugin
 __all__ = ['backends']
 
 #: Registers new backend plugins.
-backends: Plugin[type[BackendInterface]] = Plugin('pymap.backend')
+backends: Plugin[BackendInterface] = Plugin('pymap.backend')

--- a/pymap/filter.py
+++ b/pymap/filter.py
@@ -12,11 +12,11 @@ from .plugin import Plugin
 __all__ = ['filters', 'PluginFilterSet', 'SingleFilterSet']
 
 #: Registers filter compiler plugins.
-filters: Plugin[type[FilterCompilerInterface[Any]]] = Plugin(
+filters: Plugin[FilterCompilerInterface[Any]] = Plugin(
     'pymap.filter', default='sieve')
 
 
-class PluginFilterSet(FilterSetInterface[FilterValueT], metaclass=ABCMeta):
+class PluginFilterSet(FilterSetInterface[FilterValueT]):
     """Base class for filter set implementations that use a filter compiler
     declared in the ``pymap.filter`` entry point. The declared entry points
     must sub-class :class:`FilterCompiler`.

--- a/pymap/imap/__init__.py
+++ b/pymap/imap/__init__.py
@@ -37,9 +37,9 @@ from pymap.parsing.response import ResponseContinuation, Response, \
 from pymap.parsing.state import ParsingState, ParsingInterrupt, \
     ExpectContinuation
 from pymap.sockets import InheritedSockets
-from pysasl import ServerChallenge, ChallengeResponse
 from pysasl.creds.server import ServerCredentials
 from pysasl.exception import AuthenticationError
+from pysasl.mechanism import ServerChallenge, ChallengeResponse
 
 from .state import ConnectionState
 

--- a/pymap/interfaces/login.py
+++ b/pymap/interfaces/login.py
@@ -1,19 +1,18 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod, ABCMeta
-from collections.abc import Mapping, Set
+from abc import abstractmethod
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime
 from typing import Protocol
 
 from pysasl.creds.server import ServerCredentials
-from pysasl.identity import Identity
 
 from .session import SessionInterface
 from .token import TokensInterface
+from ..user import UserMetadata
 
-__all__ = ['LoginInterface', 'IdentityInterface', 'UserInterface']
+__all__ = ['LoginInterface', 'IdentityInterface']
 
 
 class LoginInterface(Protocol):
@@ -86,7 +85,7 @@ class IdentityInterface(Protocol):
         ...
 
     @abstractmethod
-    async def get(self) -> UserInterface:
+    async def get(self) -> UserMetadata:
         """Return the metadata associated with the user identity.
 
         Raises:
@@ -96,7 +95,7 @@ class IdentityInterface(Protocol):
         ...
 
     @abstractmethod
-    async def set(self, metadata: UserInterface) -> None:
+    async def set(self, metadata: UserMetadata) -> None:
         """Assign new metadata to the user identity.
 
         Args:
@@ -111,58 +110,6 @@ class IdentityInterface(Protocol):
 
         Raises:
             :exc:`~pymap.exceptions.UserNotFound`
-
-        """
-        ...
-
-
-class UserInterface(Identity, metaclass=ABCMeta):
-    """Contains information about a user."""
-
-    @property
-    @abstractmethod
-    def password(self) -> str | None:
-        """The password string or hash digest."""
-        ...
-
-    @property
-    @abstractmethod
-    def roles(self) -> Set[str]:
-        """A set of role strings given to the user. These strings only have
-        meaning to the backend.
-
-        """
-        ...
-
-    @property
-    @abstractmethod
-    def params(self) -> Mapping[str, str]:
-        """Metadata parameters associated with the user."""
-        ...
-
-    @abstractmethod
-    def get_key(self, identifier: str) -> bytes | None:
-        """Find the token key for the given identifier associated with this
-        user.
-
-        Args:
-            identifier: Any string that can facilitate the lookup of the key.
-
-        """
-        ...
-
-    @abstractmethod
-    async def check_password(self, creds: ServerCredentials) -> None:
-        """Check the given credentials against the known password comparison
-        data. If the known data used a hash, then the equivalent hash of the
-        provided secret is compared.
-
-        Args:
-            creds: The provided authentication credentials.
-            token_key: The token key bytestring.
-
-        Raises:
-            :class:`~pymap.exceptions.InvalidAuth`
 
         """
         ...

--- a/pymap/message.py
+++ b/pymap/message.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from abc import ABCMeta
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import datetime
 from typing import Any, Final
@@ -30,7 +29,7 @@ class _NoContent(ValueError):
         super().__init__('Message content not available.')
 
 
-class BaseMessage(MessageInterface, CachedMessage, metaclass=ABCMeta):
+class BaseMessage(MessageInterface, CachedMessage):
     """Message metadata such as UID, permanent flags, and when the message
     was added to the system.
 
@@ -114,7 +113,7 @@ class ExpungedMessage(BaseMessage):
         return BaseLoadedMessage(self, requirement, None)
 
 
-class BaseLoadedMessage(LoadedMessageInterface, metaclass=ABCMeta):
+class BaseLoadedMessage(LoadedMessageInterface):
     """The loaded message content, implemented using an instance of
     :class:`~pymap.mime.MessageContent`.
 

--- a/pymap/parsing/command/__init__.py
+++ b/pymap/parsing/command/__init__.py
@@ -51,7 +51,7 @@ class Command(Parseable[bytes], metaclass=ABCMeta):
         return '<%s tag=%r>' % (type(self).__name__, self.tag)
 
 
-class CommandNoArgs(Command, metaclass=ABCMeta):
+class CommandNoArgs(Command):
     """Convenience class used to fail parsing when args are given to a command
     that expects nothing.
 
@@ -64,14 +64,14 @@ class CommandNoArgs(Command, metaclass=ABCMeta):
         return cls(params.tag), buf
 
 
-class CommandAny(Command, metaclass=ABCMeta):
+class CommandAny(Command):
     """Represents a command available at any stage of the IMAP session.
 
     """
     pass
 
 
-class CommandAuth(Command, metaclass=ABCMeta):
+class CommandAuth(Command):
     """Represents a command available when the IMAP session has been
     authenticated.
 
@@ -79,7 +79,7 @@ class CommandAuth(Command, metaclass=ABCMeta):
     pass
 
 
-class CommandNonAuth(Command, metaclass=ABCMeta):
+class CommandNonAuth(Command):
     """Represents a command available only when the IMAP session has not yet
     authenticated.
 
@@ -87,7 +87,7 @@ class CommandNonAuth(Command, metaclass=ABCMeta):
     pass
 
 
-class CommandSelect(CommandAuth, metaclass=ABCMeta):
+class CommandSelect(CommandAuth):
     """Represents a command available only when the IMAP session has been
     authenticated and a mailbox has been selected.
 

--- a/pymap/parsing/command/auth.py
+++ b/pymap/parsing/command/auth.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import re
-from abc import ABCMeta
 from collections.abc import Iterable, Sequence
 from typing import ClassVar
 
@@ -20,7 +19,7 @@ __all__ = ['AppendCommand', 'CreateCommand', 'DeleteCommand', 'ExamineCommand',
            'StatusCommand', 'SubscribeCommand', 'UnsubscribeCommand']
 
 
-class CommandMailboxArg(CommandAuth, metaclass=ABCMeta):
+class CommandMailboxArg(CommandAuth):
 
     def __init__(self, tag: bytes, mailbox: Mailbox) -> None:
         super().__init__(tag)

--- a/pymap/parsing/response/__init__.py
+++ b/pymap/parsing/response/__init__.py
@@ -1,7 +1,6 @@
 
 from __future__ import annotations
 
-from abc import ABCMeta
 from collections.abc import Hashable, AsyncIterator
 from contextlib import asynccontextmanager, AbstractAsyncContextManager
 from typing import TypeAlias, TypeVar, Final
@@ -52,7 +51,7 @@ class _AnonymousResponseCode(ResponseCode):
         return BytesFormat(b'[%b]') % self.code
 
 
-class Response(Writeable, metaclass=ABCMeta):
+class Response(Writeable):
     """Base class for all responses sent from the server to the client. These
     responses may be sent unsolicited (e.g. idle timeouts) or in response to a
     tagged command from the client.

--- a/pymap/parsing/specials/fetchattr.py
+++ b/pymap/parsing/specials/fetchattr.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import enum
 import re
-from abc import ABCMeta
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from functools import total_ordering, reduce
@@ -324,7 +323,7 @@ class FetchAttribute(Parseable[bytes]):
         return self.raw
 
 
-class FetchValue(Writeable, metaclass=ABCMeta):
+class FetchValue(Writeable):
     """A value fetched from a message for a single fetch attribute.
 
     Args:

--- a/pymap/service.py
+++ b/pymap/service.py
@@ -7,4 +7,4 @@ from .plugin import Plugin
 __all__ = ['services']
 
 #: Registers new service plugins.
-services: Plugin[type[ServiceInterface]] = Plugin('pymap.service')
+services: Plugin[ServiceInterface] = Plugin('pymap.service')

--- a/pymap/sieve/manage/__init__.py
+++ b/pymap/sieve/manage/__init__.py
@@ -24,9 +24,9 @@ from pymap.interfaces.login import LoginInterface
 from pymap.interfaces.session import SessionInterface
 from pymap.parsing.exceptions import NotParseable
 from pymap.parsing.primitives import String
-from pysasl import ServerChallenge, ChallengeResponse
 from pysasl.creds.server import ServerCredentials
 from pysasl.exception import AuthenticationError
+from pysasl.mechanism import ServerChallenge, ChallengeResponse
 
 from .command import Command, NoOpCommand, LogoutCommand, CapabilityCommand, \
     AuthenticateCommand, UnauthenticateCommand, StartTLSCommand

--- a/pymap/token/__init__.py
+++ b/pymap/token/__init__.py
@@ -1,20 +1,35 @@
 
 from __future__ import annotations
 
-from collections.abc import Set
+from collections.abc import Sequence, Set
 from datetime import datetime
+from functools import cached_property
+from typing import Final
 
+from ..config import IMAPConfig
 from ..interfaces.token import TokenCredentials, TokensInterface
 from ..plugin import Plugin
 
-__all__ = ['tokens', 'AllTokens']
+__all__ = ['tokens', 'TokensBase', 'AllTokens']
 
 #: Registers token plugins.
-tokens: Plugin[type[TokensInterface]] = Plugin(
-    'pymap.token', default='macaroon')
+tokens: Plugin[TokensBase] = Plugin('pymap.token', default='macaroon')
 
 
-class AllTokens(TokensInterface):
+class TokensBase(TokensInterface):
+    """Base class for token types registered by :data:`tokens`.
+
+    Args:
+        config: The IMAP configuration object.
+
+    """
+
+    def __init__(self, config: IMAPConfig) -> None:
+        super().__init__()
+        self.config: Final = config
+
+
+class AllTokens(TokensBase):
     """Uses :data:`tokens` to support all registered token types.
 
     For token creation, the :attr:`~pymap.plugin.Plugin.default` token plugin
@@ -22,16 +37,36 @@ class AllTokens(TokensInterface):
 
     """
 
+    @cached_property
+    def _default_tokens(self) -> TokensInterface | None:
+        try:
+            token_type = tokens.default
+        except KeyError:
+            return None
+        else:
+            return token_type(self.config)
+
+    @cached_property
+    def _tokens(self) -> Sequence[TokensInterface]:
+        all_tokens = []
+        config = self.config
+        for token_type in tokens.registered.values():
+            if token_type == tokens.default:
+                assert self._default_tokens is not None
+                all_tokens.append(self._default_tokens)
+            else:
+                all_tokens.append(token_type(config))
+        return all_tokens
+
     def get_login_token(self, identifier: str, authcid: str, key: bytes, *,
                         authzid: str | None = None,
                         location: str | None = None,
                         expiration: datetime | None = None) \
             -> str | None:
-        try:
-            token_type = tokens.default
-        except KeyError:
+        tokens = self._default_tokens
+        if tokens is None:
             return None
-        return token_type().get_login_token(
+        return tokens.get_login_token(
             identifier, authcid, key, authzid=authzid, location=location,
             expiration=expiration)
 
@@ -40,21 +75,19 @@ class AllTokens(TokensInterface):
                         location: str | None = None,
                         expiration: datetime | None = None) \
             -> str | None:
-        try:
-            token_type = tokens.default
-        except KeyError:
+        tokens = self._default_tokens
+        if tokens is None:
             return None
-        return token_type().get_admin_token(
+        return tokens.get_admin_token(
             admin_key, authzid=authzid, location=location,
             expiration=expiration)
 
     def parse(self, authzid: str, token: str, *,
               admin_keys: Set[bytes] = frozenset()) \
             -> TokenCredentials:
-        for _, token_type in tokens.registered.items():
+        for tokens in self._tokens:
             try:
-                return token_type().parse(authzid, token,
-                                          admin_keys=admin_keys)
+                return tokens.parse(authzid, token, admin_keys=admin_keys)
             except ValueError:
                 pass
         raise ValueError('invalid token')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ asyncio_mode = 'auto'
 norecursedirs = 'doc'
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 90
 omit = ['*/maildir/*', '*/redis/*', '*/main.py']
 exclude_lines = [
     'pragma: no cover',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Ian C. Good
+# Copyright (c) 2022 Ian C. Good
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@ with open('LICENSE.md') as f:
     license = f.read()
 
 setup(name='pymap',
-      version='0.28.0.rc1',
+      version='0.28.0.rc2',
       author='Ian Good',
       author_email='ian@icgood.net',
       description='Lightweight, asynchronous IMAP serving in Python.',
@@ -49,7 +49,7 @@ setup(name='pymap',
       include_package_data=True,
       packages=find_packages(include=('pymap', 'pymap.*')),
       install_requires=[
-          'pysasl == 1.0.0.rc1',
+          'pysasl == 1.0.0.rc7',
           'proxy-protocol ~= 0.8.0'],
       extras_require={
           'admin': ['pymap-admin ~= 0.8.0',

--- a/test/server/base.py
+++ b/test/server/base.py
@@ -3,6 +3,7 @@ import asyncio
 from argparse import Namespace
 
 import pytest
+from pysasl.hashing import BuiltinHash
 
 from pymap.backend.dict import DictBackend
 from pymap.context import subsystem
@@ -29,6 +30,9 @@ class FakeArgs(Namespace):
 
 class TestBase:
 
+    # For speed and determinism.
+    _hash_context = BuiltinHash(hash_name='sha1', salt_len=0, rounds=1)
+
     @classmethod
     @pytest.fixture(autouse=True)
     def init(cls, request, backend):
@@ -54,7 +58,11 @@ class TestBase:
 
     @pytest.fixture
     async def backend(self, args, overrides):
-        backend, config = await DictBackend.init(args, **overrides)
+        backend, config = await DictBackend.init(
+            args,
+            hash_context=self._hash_context,
+            invalid_user_sleep=0.0,
+            **overrides)
         return backend
 
     def _incr_fd(self):

--- a/test/server/test_admin_user.py
+++ b/test/server/test_admin_user.py
@@ -29,7 +29,8 @@ class TestMailboxHandlers(TestBase):
             response = await stub.GetUser(request, metadata=self.metadata)
         assert SUCCESS == response.result.code
         assert 'testuser' == response.username
-        assert 'testpass' == response.data.password
+        assert '$pbkdf2$1$$FzEpdTtdOaIFkUucxV4PjfW88BE=' \
+            == response.data.password
 
     async def test_get_user_not_found(self, backend) -> None:
         handlers = UserHandlers(backend)


### PR DESCRIPTION
* Run auth credentials (username/password) through [SASLprep](https://datatracker.ietf.org/doc/html/rfc4013).
* Hash password changes in the `cpu_subsystem` thread pool.
* Add a configurable sleep for auth failures due to bad username.
* Misc repo, typing, and linting cleanup