### PR TITLE
[FIX] Convert SearchSet to the required frozenset

### DIFF
--- a/pymap/parsing/specials/searchkey.py
+++ b/pymap/parsing/specials/searchkey.py
@@ -186,7 +186,7 @@ class SearchKey(Parseable[bytes]):
             pass
         else:
             key_list = key_list_p.get_as(SearchKey)
-            return cls(b'KEYSET', key_list, inverse), buf
+            return cls(b'KEYSET', frozenset(key_list), inverse), buf
         atom, after = Atom.parse(buf, params)
         key = atom.value.upper()
         if key in (b'ALL', b'ANSWERED', b'DELETED', b'FLAGGED', b'NEW', b'OLD',


### PR DESCRIPTION
Great library but I encountered an issue in my testing. Below you can spot the server and client code to reproduce it. The reason for the error seems that for `KEYSET` a list is used which can't be hashed. I convert to `frozenset` because of `filter_key_set`. Initially I encountered the same with the search `(UNSEEN)`.

The pymap version is `0.27.0` because it's the latest for python 3.10.

It would be nice if we can also fix it for python 3.10.

**Running the pymap server:**
```
-> % pymap dict --demo-data --demo-user test@example.org --demo-password test
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-9' coro=<IMAPServer.__call__() done, defined at /usr/local/lib/python3.10/dist-packages/pymap/imap/__init__.py:115> exception=TypeError("unhashable type: 'list'")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/pymap/imap/__init__.py", line 122, in __call__
    await conn.run(state)
  File "/usr/local/lib/python3.10/dist-packages/pymap/imap/__init__.py", line 354, in run
    await self._run_state(state)
  File "/usr/local/lib/python3.10/dist-packages/pymap/imap/__init__.py", line 371, in _run_state
    cmd = await self.read_command(state)
  File "/usr/local/lib/python3.10/dist-packages/pymap/imap/__init__.py", line 255, in read_command
    cmd, _ = self.commands.parse(line, params)
  File "/usr/local/lib/python3.10/dist-packages/pymap/parsing/commands.py", line 161, in parse
    return cmd_type.parse(buf, params)
  File "/usr/local/lib/python3.10/dist-packages/pymap/parsing/command/select.py", line 379, in parse
    return cls(params.tag, search_keys, charset, options), buf
  File "/usr/local/lib/python3.10/dist-packages/pymap/parsing/command/select.py", line 329, in __init__
    self.keys = frozenset(keys)
  File "/usr/local/lib/python3.10/dist-packages/pymap/parsing/specials/searchkey.py", line 132, in __hash__
    return hash((self.value, self.filter, self.inverse))
TypeError: unhashable type: 'list'
```

**Client Code:** [from imaplib](https://docs.python.org/3/library/imaplib.html#imaplib.IMAP4.search)
```
from imaplib import IMAP4
with IMAP4("localhost", port=143) as mbox:
    mbox.login('test@example.org', 'test')
    mbox.list()
    mbox.select("inbox")
    mbox.search(None, '(FROM "LDJ")')
```